### PR TITLE
fix: generated typecript types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ authors = [
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-Oz", "--enable-mutable-globals"]
 
-[target.'wasm32-unknown-unknown'.dependencies]
+[target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ mod jdbc;
 mod utils;
 
 /// The WASM representations of the connection string structs.
-#[cfg(target = "wasm32-unknown-unknown")]
+#[cfg(target_arch = "wasm32")]
 pub mod wasm;
 
 pub use ado::AdoNetString;


### PR DESCRIPTION
Fixes https://github.com/prisma/connection-string/issues/8

Based on https://rustwasm.github.io/book/reference/add-wasm-support-to-crate.html and https://doc.rust-lang.org/reference/conditional-compilation.html

Without this fix, the generated `pkg/connection_string.d.ts` is empty.