### PR TITLE
Set MSRV as 1.46

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ documentation = "https://docs.rs/connection-string"
 description = "Connection string parsing in Rust (and WebAssembly)"
 readme = "README.md"
 edition = "2018"
+rust = "1.46"
 keywords = []
 categories = []
 authors = [


### PR DESCRIPTION
To resolve the compile error like below.

From\<char\> for String implementation was included from Rust 1.46.
https://github.com/rust-lang/rust/pull/73466

Then, set MSRV in Cargo.toml by https://github.com/rust-lang/rfcs/pull/2495

```
error[E0277]: the trait bound `std::string::String: std::convert::From<char>` is not satisfied
   --> src/jdbc.rs:244:22
    |
244 |     let mut output = String::from('[');
    |                      ^^^^^^^^^^^^ the trait `std::convert::From<char>` is not implemented for `std::string::String`
    |
    = help: the following implementations were found:
              <std::string::String as std::convert::From<&mut str>>
              <std::string::String as std::convert::From<&std::string::String>>
              <std::string::String as std::convert::From<&str>>
              <std::string::String as std::convert::From<std::borrow::Cow<'a, str>>>
              <std::string::String as std::convert::From<std::boxed::Box<str>>>
    = note: required by `std::convert::From::from`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0277`.
error: could not compile `connection-string`.
```