### PR TITLE
ci: Pin Rust build toolchain to 1.46 (similar to Cargo.toml)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [stable]
+        rust: [1.46]
 
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
This makes CI succeed again without code changes.